### PR TITLE
Error message email

### DIFF
--- a/lib/phax_machine_sinatra/phax_machine_sinatra.rb
+++ b/lib/phax_machine_sinatra/phax_machine_sinatra.rb
@@ -272,13 +272,13 @@ class PhaxMachineSinatra < Sinatra::Application
 		def most_common_error(fax)
 			errors = {}
 			fax["recipients"].each do |recipient|
-			  if errors.has_key?(recipient["error_code"].downcase)
-			    errors["#{recipient["error_code"]}"]["frequency"] += 1
+			  key = recipient["error_code"].downcase
+			  if errors.has_key?(key)
+			    errors[key]["frequency"] += 1
 			  else
-			    errors["#{recipient["error_code"].downcase}"] = {"frequency" => 1}
+			    errors[key] = {"frequency" => 1}
 			  end
 			end
-			# max_by returns an array that looks like '["no answer, {frequency: 3}'
-			errors.max_by {|error_code, amount| amount["frequency"]}.shift
+		  errors.max_by {|error_code, amount| amount["frequency"]}.shift
 		end
 end

--- a/lib/phax_machine_sinatra/phax_machine_sinatra.rb
+++ b/lib/phax_machine_sinatra/phax_machine_sinatra.rb
@@ -147,7 +147,8 @@ class PhaxMachineSinatra < Sinatra::Application
     if @fax["status"] == "success"
     	email_subject = "Your fax was sent successfully"
     else
-    	email_subject = "Your fax failed because #{most_common_error(@fax)}"
+    	@fax["most_common_error"] = most_common_error(@fax)
+    	email_subject = "Your fax failed because: #{@fax["most_common_error"]}"
     end
 
     Pony.mail(
@@ -267,7 +268,8 @@ class PhaxMachineSinatra < Sinatra::Application
       @db ||= Sequel.connect(ENV["DATABASE_URL"])
     end
 
-		def most_common_error(fax) #if there are two error_codes with the same frequency of occurrance, the error found first (first recipient) takes precedence
+		# if there are two error_codes with the same frequency of occurrance, the error found first (first recipient) takes precedence
+		def most_common_error(fax)
 			errors = {}
 			fax["recipients"].each do |recipient|
 			  if errors.has_key?(recipient["error_code"].downcase)
@@ -275,7 +277,8 @@ class PhaxMachineSinatra < Sinatra::Application
 			  else
 			    errors["#{recipient["error_code"].downcase}"] = {"frequency" => 1}
 			  end
-			end 
-			errors.max_by {|error_code, amount| amount["frequency"]}.shift #max_by returns an array that looks like '["no answer, {frequency: 3}'
+			end
+			# max_by returns an array that looks like '["no answer, {frequency: 3}'
+			errors.max_by {|error_code, amount| amount["frequency"]}.shift
 		end
 end

--- a/lib/phax_machine_sinatra/phax_machine_sinatra.rb
+++ b/lib/phax_machine_sinatra/phax_machine_sinatra.rb
@@ -271,9 +271,10 @@ class PhaxMachineSinatra < Sinatra::Application
     def isolate_errors(fax)
     	errors = Hash.new(0)
     	fax["recipients"].each do |recipient|
-    		if recipient["error_code"] != nil
-    			errors[recipient]["error_code"].downcase += 1
-    		end
+    		p recipient["error_code"]
+    		# if recipient["error_code"] != nil
+    		# 	errors[recipient]["error_code"].downcase
+    		# end
     	end
     	errors
     end

--- a/lib/phax_machine_sinatra/phax_machine_sinatra.rb
+++ b/lib/phax_machine_sinatra/phax_machine_sinatra.rb
@@ -108,7 +108,6 @@ class PhaxMachineSinatra < Sinatra::Application
 
   post '/fax_received' do
     @fax = JSON.parse params['fax']
-    p @fax
     recipient_number = Phonelib.parse(@fax['to_number']).e164
     begin
       user_id = db[:users].where(fax_number: recipient_number).first[:id]
@@ -144,7 +143,8 @@ class PhaxMachineSinatra < Sinatra::Application
     ensure
       db.disconnect
     end
-    email_subject = "Sent fax was a #{@fax['status']}"
+
+    @fax["status"] == "success" ? email_subject = "Your fax was sent successfully" : email_subject = "Your fax failed"
 
     Pony.mail(
       to: email_addresses,

--- a/lib/phax_machine_sinatra/phax_machine_sinatra.rb
+++ b/lib/phax_machine_sinatra/phax_machine_sinatra.rb
@@ -267,13 +267,13 @@ class PhaxMachineSinatra < Sinatra::Application
       @db ||= Sequel.connect(ENV["DATABASE_URL"])
     end
 
-		def most_common_error(fax)
+		def most_common_error(fax) #if there are two error_codes with the same frequency of occurrance, the error found first (first recipient) takes precedence
 			errors = {}
 			fax["recipients"].each do |recipient|
-			  if errors.has_key?(recipient["error_code"])
+			  if errors.has_key?(recipient["error_code"].downcase)
 			    errors["#{recipient["error_code"]}"]["frequency"] += 1
 			  else
-			    errors["#{recipient["error_code"]}"] = {"frequency" => 1}
+			    errors["#{recipient["error_code"].downcase}"] = {"frequency" => 1}
 			  end
 			end 
 			errors.max_by {|error_code, amount| amount["frequency"]}.shift #max_by returns an array that looks like '["no answer, {frequency: 3}'

--- a/lib/phax_machine_sinatra/phax_machine_sinatra.rb
+++ b/lib/phax_machine_sinatra/phax_machine_sinatra.rb
@@ -269,13 +269,16 @@ class PhaxMachineSinatra < Sinatra::Application
     end
 
     def isolate_errors(fax)
-    	errors = Hash.new(0)
+    	errors = {}
     	fax["recipients"].each do |recipient|
-    		p recipient["error_code"]
-    		# if recipient["error_code"] != nil
-    		# 	errors[recipient]["error_code"].downcase
-    		# end
+    		if errors[recipient]["error_code"].downcase
+    			errors[recipient]["error_code"]["frequency"] += 1
+    		else
+    			errors[recipient]["error_code"].downcase = {"frequency" => 0 }
+    		end
     	end
+    	p errors
     	errors
     end
+    # {"id"=>66780252, "num_pages"=>1, "cost"=>0, "direction"=>"sent", "status"=>"failure", "is_test"=>false, "requested_at"=>1520875041, "completed_at"=>1520875066, "caller_id"=>"2014167526", "recipients"=>[{"number"=>"+12242136849", "status"=>"failure", "error_id"=>112, "error_code"=>"No answer", "error_type"=>"lineError", "completed_at"=>1520875066}], "tags"=>{"user"=>"ec37f02b-c623-453f-97c1-a87e67e4b3c8"}}
 end

--- a/lib/phax_machine_sinatra/phax_machine_sinatra.rb
+++ b/lib/phax_machine_sinatra/phax_machine_sinatra.rb
@@ -272,7 +272,7 @@ class PhaxMachineSinatra < Sinatra::Application
 		def most_common_error(fax)
 			errors = {}
 			fax["recipients"].each do |recipient|
-			  key = recipient["error_code"].downcase
+			  key = recipient["error_code"]
 			  if errors.has_key?(key)
 			    errors[key]["frequency"] += 1
 			  else

--- a/lib/phax_machine_sinatra/phax_machine_sinatra.rb
+++ b/lib/phax_machine_sinatra/phax_machine_sinatra.rb
@@ -108,7 +108,7 @@ class PhaxMachineSinatra < Sinatra::Application
 
   post '/fax_received' do
     @fax = JSON.parse params['fax']
-
+    p @fax
     recipient_number = Phonelib.parse(@fax['to_number']).e164
     begin
       user_id = db[:users].where(fax_number: recipient_number).first[:id]

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -4,13 +4,16 @@
 	<% if @fax["status"] == "success" %>
   	<h1>Your fax was sent successfully</h1>
   <% else %>
-  	<h1>Your fax failed</h1>
+  	<h1>Your fax failed because <%= @fax["most_common_error"] %></h1>
   <% end %>
 <% end %>
 
 <p><b>ID:</b> <%= @fax["id"] %></p>
 <p><b>Status:</b> <%= @fax["status"] %></p>
 <p><b>Number of Pages:</b> <%= @fax["num_pages"] %></p>
+<% if @fax["status"] != "success" %>
+	<p><b>Most Common Error:</b> <%= @fax["most_common_error"] %></p>
+<% end %>
 <% if @fax["direction"] == "received" %>
   <p><b>To:</b> <%= @fax["to_number"] %></p>
 <% end %>

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -4,18 +4,18 @@
 	<% if @fax["status"] == "success" %>
   	<h1>Your fax was sent successfully</h1>
   <% else %>
-  	<h1>Your fax failed because <%= @fax["most_common_error"] %></h1>
+  	<h1>Your fax failed because: <%= @fax["most_common_error"] %></h1>
   <% end %>
 <% end %>
 
 <p><b>ID:</b> <%= @fax["id"] %></p>
 <p><b>Status:</b> <%= @fax["status"] %></p>
 <p><b>Number of Pages:</b> <%= @fax["num_pages"] %></p>
-<% if @fax["status"] != "success" %>
-	<p><b>Most Common Error:</b> <%= @fax["most_common_error"] %></p>
-<% end %>
 <% if @fax["direction"] == "received" %>
   <p><b>To:</b> <%= @fax["to_number"] %></p>
+<% end %>
+<% if @fax["status"] != "success" %>
+	<p><b>Most Common Error:</b> <%= @fax["most_common_error"] %></p>
 <% end %>
 <p><b>From:</b> <%= @fax["direction"] == "received" ? @fax["from_number"] : @fax["caller_id"] %></p>
 

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -1,7 +1,13 @@
 <% if @fax["direction"] == "received" %>
   <h1>You've received a new fax!</h1>
 <% else %>
-  <h1>Your fax was a <%= @fax["status"] %>!</h1>
+
+	<% if @fax["status"] == "success" %>
+  	<h1>Your fax was sent successfully!</h1>
+  <% else %>
+  	<h1>Your fax failed</h1>
+  <% end %>
+
 <% end %>
 
 <p><b>ID:</b> <%= @fax["id"] %></p>
@@ -11,6 +17,10 @@
   <p><b>To:</b> <%= @fax["to_number"] %></p>
 <% end %>
 <p><b>From:</b> <%= @fax["direction"] == "received" ? @fax["from_number"] : @fax["caller_id"] %></p>
+
+<% if @fax["status"] == "failed" %>
+	<p><b>Error Message:</b><%= @fax["error_message"] %></p>
+<% end %>
 
 <% if @fax["direction"] == "received" %>
   <p>The document has been attached to this email.</p>

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -1,14 +1,15 @@
 <% if @fax["direction"] == "received" %>
   <h1>You've received a new fax!</h1>
 <% else %>
-
 	<% if @fax["status"] == "success" %>
   	<h1>Your fax was sent successfully!</h1>
   <% else %>
   	<h1>Your fax failed</h1>
   <% end %>
-
 <% end %>
+
+<%= @fax %>
+
 
 <p><b>ID:</b> <%= @fax["id"] %></p>
 <p><b>Status:</b> <%= @fax["status"] %></p>

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -8,8 +8,6 @@
   <% end %>
 <% end %>
 
-<%= @fax %>
-
 <p><b>ID:</b> <%= @fax["id"] %></p>
 <p><b>Status:</b> <%= @fax["status"] %></p>
 <p><b>Number of Pages:</b> <%= @fax["num_pages"] %></p>

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -14,10 +14,10 @@
 <% if @fax["direction"] == "received" %>
   <p><b>To:</b> <%= @fax["to_number"] %></p>
 <% end %>
+<p><b>From:</b> <%= @fax["direction"] == "received" ? @fax["from_number"] : @fax["caller_id"] %></p>
 <% if @fax["status"] != "success" %>
 	<p><b>Most Common Error:</b> <%= @fax["most_common_error"] %></p>
 <% end %>
-<p><b>From:</b> <%= @fax["direction"] == "received" ? @fax["from_number"] : @fax["caller_id"] %></p>
 
 <% if @fax["direction"] == "received" %>
   <p>The document has been attached to this email.</p>

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -2,14 +2,11 @@
   <h1>You've received a new fax!</h1>
 <% else %>
 	<% if @fax["status"] == "success" %>
-  	<h1>Your fax was sent successfully!</h1>
+  	<h1>Your fax was sent successfully</h1>
   <% else %>
   	<h1>Your fax failed</h1>
   <% end %>
 <% end %>
-
-<%= @fax %>
-
 
 <p><b>ID:</b> <%= @fax["id"] %></p>
 <p><b>Status:</b> <%= @fax["status"] %></p>
@@ -19,10 +16,6 @@
 <% end %>
 <p><b>From:</b> <%= @fax["direction"] == "received" ? @fax["from_number"] : @fax["caller_id"] %></p>
 
-<% if @fax["status"] == "failed" %>
-	<p><b>Error Message:</b><%= @fax["error_message"] %></p>
-<% end %>
-
 <% if @fax["direction"] == "received" %>
   <p>The document has been attached to this email.</p>
 <% else %>
@@ -31,6 +24,9 @@
     <div class="recipient">
       <p><b>Number:</b> <%= recipient["number"] %></p>
       <p><b>Status:</b> <%= recipient["status"] %></p>
+      <% if @fax["status"] == "failure" %>
+				<p><b>Error Message:</b><%= recipient["error_code"] %></p>
+			<% end %>
     </div>
   <% end %>
 <% end %>

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -24,7 +24,7 @@
     <div class="recipient">
       <p><b>Number:</b> <%= recipient["number"] %></p>
       <p><b>Status:</b> <%= recipient["status"] %></p>
-      <% if @fax["status"] == "failure" %>
+      <% if @fax["status"] != "success" %>
 				<p><b>Error Message:</b> <%= recipient["error_code"] %></p>
 			<% end %>
     </div>

--- a/lib/phax_machine_sinatra/views/fax_email.erb
+++ b/lib/phax_machine_sinatra/views/fax_email.erb
@@ -8,6 +8,8 @@
   <% end %>
 <% end %>
 
+<%= @fax %>
+
 <p><b>ID:</b> <%= @fax["id"] %></p>
 <p><b>Status:</b> <%= @fax["status"] %></p>
 <p><b>Number of Pages:</b> <%= @fax["num_pages"] %></p>
@@ -25,7 +27,7 @@
       <p><b>Number:</b> <%= recipient["number"] %></p>
       <p><b>Status:</b> <%= recipient["status"] %></p>
       <% if @fax["status"] == "failure" %>
-				<p><b>Error Message:</b><%= recipient["error_code"] %></p>
+				<p><b>Error Message:</b> <%= recipient["error_code"] %></p>
 			<% end %>
     </div>
   <% end %>


### PR DESCRIPTION
* Changed successful fax email heading to "Your fax was successful" in phax_email.erb
* Changed failed fax email heading to "You fax failed because: [error here]" in phax_email.erb
* Added most_common_error method to phax_machine.rb that isolates the most common error from all recipients of a fax. If two or more errors occur at the same frequency, the error associated with the first sender is displayed as the most common error